### PR TITLE
Genericise dialplan so it can be included as-is without modification

### DIFF
--- a/Asterisk/dialplan/cutelcapturethephone.conf
+++ b/Asterisk/dialplan/cutelcapturethephone.conf
@@ -1,14 +1,14 @@
-; Define the CTP_CALL_PREFIX, CTP_BACKEND_URL and CTP_BACKEND_API_KEY values as environment variables
-; 
-; You'll want to add some new extensions to your extensions.conf and include this file too. Below is an example, where you may want to adjust the incoming extension
-; both in the example below and in the actual ctp contexts below.
+; You'll want to add some new extensions to your extensions.conf and include this file too. Below is an example, where you may want to adjust the incoming extension and CALL_PREFIX, BACKEND_URL and BACKEND_API_KEY directives
 ; 
 ; #include capturethephone.conf
 ; 
 ; [your-context]
-; exten => _9580000,1,Goto(ctp-register,,1)
-;  exten => _958XXXX,1,Goto(ctp-capture,,1)
-;     same => n,Hangup()
+; exten => _958XXXX,Noop(Processing CTP call)
+;    same => n,Set(CALL_PREFIX=958)
+;    same => n,Set(BACKEND_URL=http://127.0.0.1:5293)
+;    same => n,Set(BACKEND_API_KEY=changeme)
+;    same => n,ExecIf($["${EXTEN:-4:4}" = "0000"]?Goto(ctp-register,,1):Goto(ctp-capture,,1))
+;    same => n,Hangup()
 
 [ctp-register]
 exten => s,1,Hangup()
@@ -16,10 +16,6 @@ exten => e,1,Hangup()
 
 ; Game Registration Service
 exten => _X.,1,Verbose(2,Registration call received from ${CALLERID(num)})
-    same => n,Set(CALL_PREFIX=${ENV(CTP_CALL_PREFIX)})
-    same => n,Set((BACKEND_URL=${ENV(CTP_BACKEND_URL)})
-    same => n,Set((BACKEND_API_KEY=${ENV(CTP_BACKEND_API_KEY)})
-
     same => n,Set(SAY_DTMF_INTERRUPT=0) ;Disable DTMF interruption of digit readout
     same => n,Set(CHANNEL(language)=cutelcapturethephone)
     same => n,Set(TIMEOUT(absolute)=900) ;15 min max timeout before automatic hangup
@@ -89,10 +85,6 @@ exten => e,1,Hangup()
 
 ; Game Capturing Service
 exten => _X.,1,Verbose(2,Capture call recived from ${CALLERID(num)} to ${EXTEN})
-    same => n,Set(CALL_PREFIX=${ENV(CTP_CALL_PREFIX)})
-    same => n,Set((BACKEND_URL=${ENV(CTP_BACKEND_URL)})
-    same => n,Set((BACKEND_API_KEY=${ENV(CTP_BACKEND_API_KEY)})
-
     same => n,Set(SAY_DTMF_INTERRUPT=0) ;Disable DTMF interruption of digit readout
     same => n,Set(CHANNEL(language)=cutelcapturethephone)
     same => n,Set(TIMEOUT(absolute)=900) ;15 min max timeout before automatic hangup


### PR DESCRIPTION
Shift setting variables to parent context so it can be included without further modification. This allows the user to hard code them, use globals or env vars